### PR TITLE
make which fields to log configurable

### DIFF
--- a/build_and_push_image.sh
+++ b/build_and_push_image.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# builds and pushes docker kong image
+# Usage: scripts/push_image.sh [TAG] (defaults to using <DATE>-<GIT_SHORT_HASH>)
+TAG=$1
+
+set -euo pipefail
+
+if [ -z "$TAG" ]; then
+  TAG="latest"
+  echo "Release tag: ${TAG}"
+fi
+
+AWS_REGION="us-east-1"
+AWS_ACCOUNT_ID="$(aws sts get-caller-identity --output text --query 'Account')"
+eval $(aws ecr get-login --no-include-email --region ${AWS_REGION} | sed 's|https://||')
+
+URL="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/kong:${TAG}"
+docker pull kong:$TAG
+
+docker tag kong:$TAG $URL
+docker push $URL
+
+
+echo "built and pushed $URL"

--- a/build_and_push_image.sh
+++ b/build_and_push_image.sh
@@ -6,7 +6,9 @@ TAG=$1
 set -euo pipefail
 
 if [ -z "$TAG" ]; then
-  TAG="latest"
+  GIT_HASH=`git rev-parse --short HEAD`
+  DATE=`date +%Y_%m_%d`
+  TAG="v${DATE}-${GIT_HASH}"
   echo "Release tag: ${TAG}"
 fi
 
@@ -15,10 +17,7 @@ AWS_ACCOUNT_ID="$(aws sts get-caller-identity --output text --query 'Account')"
 eval $(aws ecr get-login --no-include-email --region ${AWS_REGION} | sed 's|https://||')
 
 URL="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/kong:${TAG}"
-docker pull kong:$TAG
-
-docker tag kong:$TAG $URL
+docker build -t $URL .
 docker push $URL
-
-
+echo
 echo "built and pushed $URL"

--- a/kong_declarative.yml
+++ b/kong_declarative.yml
@@ -11,9 +11,37 @@ services:
 plugins:
 - name: request-termination
   service: health
-  config: 
+  config:
     status_code: 200
     message: OK
 
 - name: stdout-log
   service: health
+  config:
+    allowed_fields:
+    - request
+    - response
+    - latencies
+    - authenticated_entity
+    - client_ip
+    - consumer
+    - started_at
+    - tries
+    - upstream_uri
+    allowed_request_fields:
+    - uri
+    - url
+    - method
+    - headers
+    - size
+    - tls
+    allowed_request_headers:
+    - user-agent
+    - accept
+    allowed_response_fields:
+    - size
+    - status
+    allowed_latencies_fields:
+    - kong
+    - proxy
+    - request

--- a/stdout-log/handler.lua
+++ b/stdout-log/handler.lua
@@ -1,13 +1,9 @@
 local cjson = require "cjson"
 local basic_serializer = require "kong.plugins.log-serializers.basic"
-local ffi = require("ffi")
 local BasePlugin = require "kong.plugins.base_plugin"
 local StdoutLogHandler = BasePlugin:extend()
 -- https://docs.konghq.com/1.3.x/plugin-development/custom-logic/
 
-ffi.cdef[[
-   int printf(const char *fmt, ...);
-]]
 -- lower is later, < 10 for logging
 StdoutLogHandler.PRIORITY = 9
 StdoutLogHandler.VERSION = "0.0.1"
@@ -16,24 +12,86 @@ function StdoutLogHandler:new()
   StdoutLogHandler.super.new(self, "stdout-log")
 end
 
+function filterSerializedFields(serialized, conf)
+  local filtered_fields = {}
+
+  for field, value in pairs(serialized) do
+    for _, allowed_field in pairs(conf.allowed_fields) do
+      if field == allowed_field then
+        if field == "request" then
+          filtered_fields["request"] = {}
+          for request_field, request_value in pairs(value) do
+            for _, allowed_request_field in pairs(conf.allowed_request_fields) do
+              if allowed_request_field == request_field then
+                if request_field == "headers" then
+                  filtered_fields["request"]["headers"] = {}
+                  for header, header_value in pairs(request_value) do
+                    for _, allowed_header in pairs(conf.allowed_request_headers) do
+                      if header == allowed_header then
+                        filtered_fields[field][request_field][header] = header_value
+                      end
+                    end
+                  end
+                elseif request_field == "querystring" then
+                  filtered_fields["request"]["querystring"] = {}
+                  for querystring_field, querystring_value in pairs(request_value) do
+                    for _, allowed_querystring_field in pairs(conf.allowed_request_querystring_fields) do
+                      if querystring_field == allowed_querystring_field then
+                        filtered_fields[field][request_field][querystring_field] = querystring_value
+                      end
+                    end
+                  end
+                else
+                  filtered_fields["request"][request_field] = request_value
+                end
+              end
+            end
+          end
+
+        elseif field == "response" then
+          filtered_fields["response"] = {}
+          for response_field, response_value in pairs(value) do
+            for _, allowed_response_field in pairs(conf.allowed_response_fields) do
+              if allowed_response_field == response_field then
+                if response_field == "headers" then
+                  filtered_fields["response"]["headers"] = {}
+                  for header, header_value in pairs(response_value) do
+                    for _, allowed_header in pairs(conf.allowed_response_headers) do
+                      if header == allowed_header then
+                        filtered_fields[field][response_field][header] = header_value
+                      end
+                    end
+                  end
+                else
+                  filtered_fields["response"][response_field] = response_value
+                end
+              end
+            end
+          end
+        elseif field == "latencies" then
+          filtered_fields["latencies"] = {}
+          for latencies_field, latencies_value in pairs(value) do
+            for _, allowed_latencies_field in pairs(conf.allowed_latencies_fields) do
+              if allowed_latencies_field == latencies_field then
+                filtered_fields["latencies"][latencies_field] = latencies_value
+              end
+            end
+          end
+        else
+          filtered_fields[field] = value
+        end
+      end
+    end
+  end
+
+  return filtered_fields
+end
+
 function StdoutLogHandler:log(conf)
   StdoutLogHandler.super.log(self)
-  local message = basic_serializer.serialize(ngx)
-  local headers = {}
-  message['service'] = nil
-  message['route'] = nil
-  message['route'] = nil
-  -- Let's only log headers that are safe, e.g. in particular NOT 'authorization'
-  if message['request'] ~= nil then
-    headers['user-agent'] = message['request']['headers']['user-agent']
-    headers['accept'] = message['request']['headers']['accept']
-    message['request']['headers'] = headers
-    message['request']['querystring'] = nil
-  end
-  if message['response'] ~= nil then
-    message['response']['headers'] = nil
-  end
-  ffi.C.printf(cjson.encode(message) .. "\n")
+  local message = filterSerializedFields(basic_serializer.serialize(ngx), conf)
+
+  io.stdout:write(cjson.encode(message) .. "\n")
 end
 
 return StdoutLogHandler

--- a/stdout-log/schema.lua
+++ b/stdout-log/schema.lua
@@ -1,7 +1,12 @@
+-- https://docs.konghq.com/1.3.x/plugin-development/plugin-configuration/
 local typedefs = require "kong.db.schema.typedefs"
 
--- TODO: could we have a config to enumerate fields we want to log?
--- https://docs.konghq.com/1.3.x/plugin-development/plugin-configuration/
+local array_of_field_names = {
+    type = "array",
+    default = {},
+    elements = { type = "string" },
+}
+
 return {
     name = "stdout-log",
     fields = {
@@ -9,42 +14,14 @@ return {
         { config = {
             type = "record",
             fields = {
-                { allowed_fields = {
-                    type = "array",
-                    default = { },
-                    elements = { type = "string" },
-                }, },
-                { allowed_request_fields = {
-                    type = "array",
-                    default = { },
-                    elements = { type = "string" },
-                }, },
-                { allowed_response_fields = {
-                    type = "array",
-                    default = { },
-                    elements = { type = "string" },
-                }, },
-                { allowed_latencies_fields = {
-                    type = "array",
-                    default = { },
-                    elements = { type = "string" },
-                }, },
-                { allowed_request_headers = {
-                    type = "array",
-                    default = { },
-                    elements = { type = "string" },
-                }, },
-                { allowed_response_headers = {
-                    type = "array",
-                    default = { },
-                    elements = { type = "string" },
-                }, },
-                { allowed_request_querystring_fields = {
-                    type = "array",
-                    default = { },
-                    elements = { type = "string" },
-                }, },
-            }, },
-        },
+                { allowed_fields = array_of_field_names, },
+                { allowed_request_fields = array_of_field_names, },
+                { allowed_request_headers = array_of_field_names, },
+                { allowed_request_querystring_fields = array_of_field_names, },
+                { allowed_response_fields = array_of_field_names, },
+                { allowed_response_headers = array_of_field_names, },
+                { allowed_latencies_fields = array_of_field_names, },
+            },
+        }, },
     },
 }

--- a/stdout-log/schema.lua
+++ b/stdout-log/schema.lua
@@ -1,12 +1,50 @@
+local typedefs = require "kong.db.schema.typedefs"
+
 -- TODO: could we have a config to enumerate fields we want to log?
 -- https://docs.konghq.com/1.3.x/plugin-development/plugin-configuration/
 return {
-    no_consumer = true, -- this plugin will only be API-wide,
+    name = "stdout-log",
     fields = {
-        -- Describe your plugin's configuration's schema here.
+        { consumer = typedefs.no_consumer, },
+        { config = {
+            type = "record",
+            fields = {
+                { allowed_fields = {
+                    type = "array",
+                    default = { },
+                    elements = { type = "string" },
+                }, },
+                { allowed_request_fields = {
+                    type = "array",
+                    default = { },
+                    elements = { type = "string" },
+                }, },
+                { allowed_response_fields = {
+                    type = "array",
+                    default = { },
+                    elements = { type = "string" },
+                }, },
+                { allowed_latencies_fields = {
+                    type = "array",
+                    default = { },
+                    elements = { type = "string" },
+                }, },
+                { allowed_request_headers = {
+                    type = "array",
+                    default = { },
+                    elements = { type = "string" },
+                }, },
+                { allowed_response_headers = {
+                    type = "array",
+                    default = { },
+                    elements = { type = "string" },
+                }, },
+                { allowed_request_querystring_fields = {
+                    type = "array",
+                    default = { },
+                    elements = { type = "string" },
+                }, },
+            }, },
+        },
     },
-    self_check = function(schema, plugin_t, dao, is_updating)
-        -- perform any custom verification
-         return true
-    end
 }


### PR DESCRIPTION
This PR:

* makes a slight change to the mechanism we get to stdout with (`io.sdtout:write` rather than `ffi.C.printf`)
* allows us to explicitly specify which fields of the detailed log output should be logged.

The `kong_declarative.yml` uses that configurability to replicate what is currently hardcoded in `master`: https://github.com/bneutra/kong-stdout-log/blob/ee5c1075b8a90bc5acbec2ba140c0861f7ba2497/stdout-log/handler.lua#L22-L35

I've also merged in your commits from `brendan-ecr` for building and pushing.

## Questions

* I've done the configuration options as an "allow-list" rather than a "forbidden-list". That could certainly be inverted if you prefer, and we could also offer both if that seems desirable too (maybe raise some sort of error if you try to use both at the same time?)
* I've not set _anything_ to be default opted-in, since it would be somewhat tricky to predict, but I'm open to other thoughts there
* I have no sense of "typical lua style" so please if there are any issues there, feel free to raise them. I mostly took a look at the existing upstream plugins for inspiration https://github.com/Kong/kong/tree/master/kong/plugins
* I'd like to put a quick couple of test cases together - is there any particular way to set that up such that our CI would call it (if we had that hooked up / eventually as an internal repo)?

cc @bneutra 